### PR TITLE
Update publishing actions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,3 +24,4 @@ jobs:
         run: ./gradlew -Pversion=${{ secrets.GITHUB_REF }} publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_USERNAME: ${{ secrets.GITHUB_ACTOR }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 .gradle/
 build/
+.env

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,6 @@ plugins {
     `maven-publish`
 }
 
-group = "dev.smyrick"
-
 repositories {
     mavenCentral()
 }
@@ -61,8 +59,8 @@ publishing {
             name = "GitHubPackages"
             url = uri("https://maven.pkg.github.com/smyrick/kotlin-extensions")
             credentials {
-                username = findProperty("gpr.user") as String? ?: System.getenv("GITHUB_USERNAME")
-                password = findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
+                username = System.getenv("GITHUB_USERNAME")
+                password = System.getenv("GITHUB_TOKEN")
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
+group=dev.smyrick
 version=0.0.1-SNAPSHOT


### PR DESCRIPTION
Update GH Actions to send all env variables to be able to publish. I ran this locally and published 0.0.1-SNAPSHOT

https://github.com/smyrick/kotlin-extensions/packages/55467